### PR TITLE
add: OAuth 로그인 redirectUri 동적으로 요청 처리(state param)

### DIFF
--- a/src/main/java/com/edio/common/config/SwaggerConfig.java
+++ b/src/main/java/com/edio/common/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 /*
@@ -18,7 +19,11 @@ import org.springframework.context.annotation.Configuration;
                 description = "Edio API Documents<br><br>" +
                         "토큰 발급: https://ec2-3-38-251-128.ap-northeast-2.compute.amazonaws.com/oauth2/authorization/google"
         ),
-        security = @SecurityRequirement(name = "bearerAuth")
+        security = @SecurityRequirement(name = "bearerAuth"),
+        servers = {
+                @Server(url = "https://ec2-3-38-251-128.ap-northeast-2.compute.amazonaws.com",
+                        description = "서버 URL"),
+        }
 )
 @SecurityScheme(
         name = "bearerAuth",

--- a/src/main/java/com/edio/common/security/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/edio/common/security/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,61 @@
+package com.edio.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환용
+
+    public CustomAuthorizationRequestResolver(OAuth2AuthorizationRequestResolver defaultResolver) {
+        this.defaultResolver = defaultResolver;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(authorizationRequest, request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(authorizationRequest, request);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+
+        // CSRF 토큰 생성 및 프론트에서 전달된 state 값 가져오기
+        String csrfToken = UUID.randomUUID().toString(); // CSRF 방지용 랜덤 값 생성
+        String frontendState = request.getParameter("state"); // 프론트에서 전달된 state
+
+        // state 값을 JSON 형태로 생성 (CSRF 토큰 + 리다이렉트 URI)
+        Map<String, String> stateMap = new HashMap<>();
+        stateMap.put("csrfToken", csrfToken);
+        stateMap.put("redirectUri", frontendState); // 프론트에서 전달된 state를 redirectUri로 처리
+
+        String encodedState = null;
+        try {
+            String stateJson = objectMapper.writeValueAsString(stateMap); // JSON 변환
+            encodedState = Base64.getEncoder().encodeToString(stateJson.getBytes(StandardCharsets.UTF_8)); // Base64 인코딩
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to encode state", e);
+        }
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .state(encodedState) // state에 인코딩된 값 설정
+                .build();
+    }
+}

--- a/src/main/java/com/edio/common/security/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/edio/common/security/CustomAuthorizationRequestResolver.java
@@ -2,6 +2,7 @@ package com.edio.common.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
@@ -11,14 +12,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+@RequiredArgsConstructor
 public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
     private final OAuth2AuthorizationRequestResolver defaultResolver;
-    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환용
 
-    public CustomAuthorizationRequestResolver(OAuth2AuthorizationRequestResolver defaultResolver) {
-        this.defaultResolver = defaultResolver;
-    }
+    private final ObjectMapper objectMapper;
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {

--- a/src/main/java/com/edio/common/security/OAuth2ResolverConfig.java
+++ b/src/main/java/com/edio/common/security/OAuth2ResolverConfig.java
@@ -1,0 +1,21 @@
+package com.edio.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+
+@Configuration
+public class OAuth2ResolverConfig {
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        // 기본 Resolver 생성
+        DefaultOAuth2AuthorizationRequestResolver defaultResolver =
+                new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
+
+        // Custom Resolver로 감싸기
+        return new CustomAuthorizationRequestResolver(defaultResolver);
+    }
+}

--- a/src/main/java/com/edio/common/security/OAuth2ResolverConfig.java
+++ b/src/main/java/com/edio/common/security/OAuth2ResolverConfig.java
@@ -1,5 +1,6 @@
 package com.edio.common.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -10,12 +11,14 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 public class OAuth2ResolverConfig {
 
     @Bean
-    public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+    public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
+            ObjectMapper objectMapper) {
         // 기본 Resolver 생성
         DefaultOAuth2AuthorizationRequestResolver defaultResolver =
                 new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
 
-        // Custom Resolver로 감싸기
-        return new CustomAuthorizationRequestResolver(defaultResolver);
+        // Custom Resolver 생성
+        return new CustomAuthorizationRequestResolver(defaultResolver, objectMapper);
     }
 }

--- a/src/main/java/com/edio/common/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/edio/common/security/OAuth2SuccessHandler.java
@@ -24,7 +24,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {

--- a/src/main/java/com/edio/common/security/SecurityConfig.java
+++ b/src/main/java/com/edio/common/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -36,6 +37,8 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final OAuth2AuthorizationRequestResolver authorizationRequestResolver;
 
     @Value("${redirect.url}")
     private String redirectUrl;
@@ -60,6 +63,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authEndpoint ->
+                                authEndpoint.authorizationRequestResolver(authorizationRequestResolver)
+                        )
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                 )


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- OAuth 로그인 성공 시 프론트에서 요청한 redirectUri로 응답되도록 수정
- OAuth 요청 시 state를 통해 csrf를 방지하는데 보통 redirectUri를 state 파라미터로 받아서 처리
- state에 csrf용 UUID 생성 및 redirectUri 세팅 후 JSON 포맷 변경
- successHandler에서는 decode를 통해 state검증 및 redirectUri로 응답
- 기존에 spring security가 자동으로 state를 통해 csrf검증을 진행하지만 redirectUri가 추가되면서 수동으로 검증을 진행해야 하는 상황(추후에 state[메모리, 세션 등] 저장 및 검증 로직 추가 필요)인데 이 부분에 대해서 피드백 있으면 부탁 드립니다.
<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
