### PR TITLE
add: root 디렉토리 처리 및 하위 폴더 조회 depth 조정

### DIFF
--- a/src/main/java/com/edio/studywithcard/folder/controller/FolderController.java
+++ b/src/main/java/com/edio/studywithcard/folder/controller/FolderController.java
@@ -6,7 +6,6 @@ import com.edio.studywithcard.folder.model.request.FolderUpdateRequest;
 import com.edio.studywithcard.folder.model.response.FolderResponse;
 import com.edio.studywithcard.folder.service.FolderService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
@@ -26,15 +25,22 @@ public class FolderController {
         this.folderService = folderService;
     }
 
+//    @GetMapping("/folder")
+//    @Operation(summary = "Folder 정보 조회", description = "Folder 정보를 조회합니다.")
+//    public List<FolderResponse> getFolders(@Parameter(required = true, description = "사용자 ID") Long accountId){
+//        return folderService.findOneFolder(accountId);
+//    }
+
     @GetMapping("/folder")
-    @Operation(summary = "Folder 정보 조회", description = "Folder 정보를 조회합니다.")
-    public List<FolderResponse> getFolders(@Parameter(required = true, description = "사용자 ID") Long accountId){
-        return folderService.findOneFolder(accountId);
+    public List<FolderResponse> getFolders(
+            @RequestParam Long accountId,
+            @RequestParam(required = false) Long folderId) {
+        return folderService.getFolders(accountId, folderId);
     }
 
     @PostMapping("/folder")
     @Operation(summary = "Folder 등록", description = "Folder를 등록합니다.")
-    public FolderResponse createFolder(@RequestBody FolderCreateRequest folderCreateRequest){
+    public FolderResponse createFolder(@RequestBody FolderCreateRequest folderCreateRequest) {
         return folderService.createFolder(folderCreateRequest);
     }
 

--- a/src/main/java/com/edio/studywithcard/folder/model/response/FolderResponse.java
+++ b/src/main/java/com/edio/studywithcard/folder/model/response/FolderResponse.java
@@ -4,10 +4,6 @@ import com.edio.studywithcard.folder.domain.Folder;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,28 +11,18 @@ import java.util.stream.Collectors;
 @Setter
 public class FolderResponse {
     private Long id;
-    //    private Long accountId;
     private Long parentId;
     private String name;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    //    private boolean isDeleted;
-    private List<FolderResponse> childrenFolders = new ArrayList<>();
 
     public static FolderResponse from(Folder folder) {
-        List<FolderResponse> childrenResponses = folder.getChildrenFolders().stream()
-                .filter(child -> !child.isDeleted()) // 삭제되지 않은 자식 필터링
-                .map(FolderResponse::from) // 재귀적으로 Folder -> FolderResponse 변환
-                .sorted(Comparator.comparing(FolderResponse::getUpdatedAt).reversed())
-                .collect(Collectors.toList());
-
         return new FolderResponse(
                 folder.getId(),
                 folder.getParentFolder() != null ? folder.getParentFolder().getId() : null,
                 folder.getName(),
                 folder.getCreatedAt(),
-                folder.getUpdatedAt(),
-                childrenResponses
+                folder.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/edio/studywithcard/folder/repository/FolderRepository.java
+++ b/src/main/java/com/edio/studywithcard/folder/repository/FolderRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-    Optional<Folder> findByAccountIdAndNameAndIsDeleted(Long accountId, String name, boolean isDeleted);
+    List<Folder> findAllByAccountIdAndParentFolderIdAndIsDeleted(Long accountId, Long rootFolderId, boolean isDeleted);
 
     List<Folder> findAllByAccountIdAndParentFolderIsNullAndIsDeleted(Long accountId, boolean isDeleted);
 

--- a/src/main/java/com/edio/studywithcard/folder/service/FolderService.java
+++ b/src/main/java/com/edio/studywithcard/folder/service/FolderService.java
@@ -8,11 +8,14 @@ import java.util.List;
 
 public interface FolderService {
     // Folder 조회
-    List<FolderResponse> findOneFolder(Long accountId);
+    List<FolderResponse> getFolders(Long accountId, Long folderId);
+
     // Folder 등록
     FolderResponse createFolder(FolderCreateRequest folderCreateRequest);
+
     // Folder 수정(이름)
     void updateFolder(Long id, FolderUpdateRequest folderUpdateRequest);
+
     // Folder 삭제
     void deleteFolder(Long id);
 }

--- a/src/main/java/com/edio/user/domain/Account.java
+++ b/src/main/java/com/edio/user/domain/Account.java
@@ -17,8 +17,10 @@ public class Account extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String loginId;
 
-    @Column(nullable = true)
     private String password;
+    
+    @Setter
+    private Long rootFolderId;
 
     @Column(nullable = false)
     @Builder.Default

--- a/src/main/java/com/edio/user/service/AccountService.java
+++ b/src/main/java/com/edio/user/service/AccountService.java
@@ -6,6 +6,10 @@ import com.edio.user.model.response.AccountResponse;
 public interface AccountService {
     // Account 조회
     AccountResponse findOneAccount(String loginId);
+
     // Account 등록
     AccountResponse createAccount(AccountCreateRequest accountCreateRequest);
+
+    // RootFolderId 등록
+    void updateRootFolderId(Long accountId, Long rootFolderId);
 }

--- a/src/main/java/com/edio/user/service/AccountServiceImpl.java
+++ b/src/main/java/com/edio/user/service/AccountServiceImpl.java
@@ -53,4 +53,16 @@ public class AccountServiceImpl implements AccountService {
             throw new ConflictException(Account.class, accountCreateRequest.getLoginId());
         }
     }
+
+    /*
+        RootFolderId 수정
+     */
+    @Override
+    @Transactional
+    public void updateRootFolderId(Long accountId, Long rootFolderId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new NotFoundException(Account.class, accountId));
+
+        account.setRootFolderId(rootFolderId);
+    }
 }

--- a/src/test/java/com/edio/service/FolderServiceTests.java
+++ b/src/test/java/com/edio/service/FolderServiceTests.java
@@ -261,13 +261,11 @@ public class FolderServiceTests {
         when(folderRepository.findAllByAccountIdAndParentFolderIsNullAndIsDeleted(accountId, false)).thenReturn(rootFolders);
 
         // when
-        List<FolderResponse> response = folderService.findOneFolder(accountId);
+        List<FolderResponse> response = folderService.getFolders(accountId, null);
 
         // then
         assertThat(response).isNotNull();
         assertThat(response.size()).isEqualTo(1);
         assertThat(response.get(0).getName()).isEqualTo("Root Folder");
-        assertThat(response.get(0).getChildrenFolders().size()).isEqualTo(1);
-        assertThat(response.get(0).getChildrenFolders().get(0).getName()).isEqualTo("Child Folder");
     }
 }

--- a/src/test/java/com/edio/service/FolderServiceTests.java
+++ b/src/test/java/com/edio/service/FolderServiceTests.java
@@ -258,10 +258,10 @@ public class FolderServiceTests {
         rootFolder.getChildrenFolders().add(childFolder);
 
         List<Folder> rootFolders = List.of(rootFolder);
-        when(folderRepository.findAllByAccountIdAndParentFolderIsNullAndIsDeleted(accountId, false)).thenReturn(rootFolders);
+        when(folderRepository.findAllByAccountIdAndParentFolderIdAndIsDeleted(accountId, 1L, false)).thenReturn(rootFolders);
 
         // when
-        List<FolderResponse> response = folderService.getFolders(accountId, null);
+        List<FolderResponse> response = folderService.getFolders(accountId, 1L);
 
         // then
         assertThat(response).isNotNull();


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- 사용자 회원가입 시점에 rootFolder 생성 및 account테이블에 rootFolderId 업데이트
- 폴더 조회 시 accountId만 들어올 경우 루트 하위 디렉토리 조회(1depth)
- 폴더 조회 시 accountId, folderId가 들어올 경우 folderId 기준 하위 디렉토리 조회(1depth)
- folderResponse에 childFolders제거 (1depth이기 때문에 조회 불필요)  
<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
