### PR TITLE
add/Deck 첨부 파일 API 적용(deck, attachment_deck_target, attachment)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // AWS S3
+    implementation group: 'software.amazon.awssdk', name: 's3', version: '2.29.31'
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     // Swagger UI

--- a/src/main/java/com/edio/EdioBackendApplication.java
+++ b/src/main/java/com/edio/EdioBackendApplication.java
@@ -28,6 +28,11 @@ public class EdioBackendApplication {
 
         System.setProperty("redirect.url", dotenv.get("REDIRECT_URL"));
 
+        System.setProperty("AWS_REGION", dotenv.get("AWS_REGION"));
+        System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
+        System.setProperty("AWS_SECRET_KEY_ID", dotenv.get("AWS_SECRET_KEY_ID"));
+        System.setProperty("AWS_BUCKET_NAME", dotenv.get("AWS_BUCKET_NAME"));
+
         SpringApplication.run(EdioBackendApplication.class, args);
     }
 }

--- a/src/main/java/com/edio/common/config/S3Config.java
+++ b/src/main/java/com/edio/common/config/S3Config.java
@@ -1,0 +1,26 @@
+package com.edio.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(System.getProperty("AWS_REGION")))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        System.getProperty("AWS_ACCESS_KEY_ID"),
+                                        System.getProperty("AWS_SECRET_KEY_ID")
+                                )
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/edio/common/exception/BadRequestException.java
+++ b/src/main/java/com/edio/common/exception/BadRequestException.java
@@ -1,13 +1,14 @@
 package com.edio.common.exception;
 
+import com.edio.common.domain.BaseEntity;
 import org.springframework.http.HttpStatus;
 
 public class BadRequestException extends BaseException {
-    public <T> BadRequestException(Class<T> entityClass, Long id) {
+    public <T extends BaseEntity> BadRequestException(Class<T> entityClass, Long id) {
         super(HttpStatus.BAD_REQUEST, String.format("%s bad request: %d", entityClass.getSimpleName(), id));
     }
 
-    public <T> BadRequestException(Class<T> entityClass, Object message) {
+    public <T extends BaseEntity> BadRequestException(Class<T> entityClass, Object message) {
         super(HttpStatus.BAD_REQUEST, String.format("%s bad request: %s", entityClass.getSimpleName(), message));
     }
 }

--- a/src/main/java/com/edio/common/exception/ConflictException.java
+++ b/src/main/java/com/edio/common/exception/ConflictException.java
@@ -1,13 +1,14 @@
 package com.edio.common.exception;
 
+import com.edio.common.domain.BaseEntity;
 import org.springframework.http.HttpStatus;
 
 public class ConflictException extends BaseException {
-    public <T> ConflictException(Class<T> entityClass, Long id) {
+    public <T extends BaseEntity> ConflictException(Class<T> entityClass, Long id) {
         super(HttpStatus.CONFLICT, String.format("%s not found: %d", entityClass.getSimpleName(), id));
     }
 
-    public <T> ConflictException(Class<T> entityClass, Object message) {
+    public <T extends BaseEntity> ConflictException(Class<T> entityClass, Object message) {
         super(HttpStatus.CONFLICT, String.format("%s not found: %s", entityClass.getSimpleName(), message));
     }
 }

--- a/src/main/java/com/edio/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/edio/common/exception/GlobalExceptionHandler.java
@@ -16,5 +16,4 @@ public class GlobalExceptionHandler {
         ErrorResponse response = new ErrorResponse(ex.isSuccess(), ex.getDetailMessage());
         return new ResponseEntity<>(response, ex.getStatus());
     }
-
 }

--- a/src/main/java/com/edio/common/exception/InternalServerException.java
+++ b/src/main/java/com/edio/common/exception/InternalServerException.java
@@ -1,0 +1,13 @@
+package com.edio.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends BaseException {
+    public <T> InternalServerException(Class<T> entityClass, Long id) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, String.format("%s internal server error: %d", entityClass.getSimpleName(), id));
+    }
+
+    public <T> InternalServerException(Class<T> entityClass, Object message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, String.format("%s internal server error: %s", entityClass.getSimpleName(), message));
+    }
+}

--- a/src/main/java/com/edio/common/exception/InternalServerException.java
+++ b/src/main/java/com/edio/common/exception/InternalServerException.java
@@ -3,11 +3,11 @@ package com.edio.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class InternalServerException extends BaseException {
-    public <T> InternalServerException(Class<T> entityClass, Long id) {
-        super(HttpStatus.INTERNAL_SERVER_ERROR, String.format("%s internal server error: %d", entityClass.getSimpleName(), id));
+    public <T> InternalServerException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
     }
 
-    public <T> InternalServerException(Class<T> entityClass, Object message) {
-        super(HttpStatus.INTERNAL_SERVER_ERROR, String.format("%s internal server error: %s", entityClass.getSimpleName(), message));
+    public <T> InternalServerException(String message, Throwable cause) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, cause.getMessage());
     }
 }

--- a/src/main/java/com/edio/common/exception/NotFoundException.java
+++ b/src/main/java/com/edio/common/exception/NotFoundException.java
@@ -1,13 +1,14 @@
 package com.edio.common.exception;
 
+import com.edio.common.domain.BaseEntity;
 import org.springframework.http.HttpStatus;
 
 public class NotFoundException extends BaseException {
-    public <T> NotFoundException(Class<T> entityClass, Long id) {
+    public <T extends BaseEntity> NotFoundException(Class<T> entityClass, Long id) {
         super(HttpStatus.NOT_FOUND, String.format("%s not found: %d", entityClass.getSimpleName(), id));
     }
 
-    public <T> NotFoundException(Class<T> entityClass, Object message) {
+    public <T extends BaseEntity> NotFoundException(Class<T> entityClass, Object message) {
         super(HttpStatus.NOT_FOUND, String.format("%s not found: %s", entityClass.getSimpleName(), message));
     }
 }

--- a/src/main/java/com/edio/studywithcard/attachment/controller/AttachmentController.java
+++ b/src/main/java/com/edio/studywithcard/attachment/controller/AttachmentController.java
@@ -42,7 +42,7 @@ public class AttachmentController {
      * @ 테스트
      */
     @DeleteMapping("/attachment")
-    public void uploadFile(@RequestParam("filePath") String filePath) {
+    public void deleteFile(@RequestParam("filePath") String filePath) {
         attachmentService.deleteAttachment(filePath);
     }
 }

--- a/src/main/java/com/edio/studywithcard/attachment/controller/AttachmentController.java
+++ b/src/main/java/com/edio/studywithcard/attachment/controller/AttachmentController.java
@@ -1,0 +1,48 @@
+package com.edio.studywithcard.attachment.controller;
+
+import com.edio.common.model.response.SwaggerCommonResponses;
+import com.edio.studywithcard.attachment.domain.Attachment;
+import com.edio.studywithcard.attachment.service.AttachmentService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Tag(name = "Attachment", description = "Attachment 관련 API")
+@SecurityRequirement(name = "bearerAuth")
+@SwaggerCommonResponses
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AttachmentController {
+
+    private final AttachmentService attachmentService;
+
+    /**
+     * @param file
+     * @param folder
+     * @return
+     * @throws IOException
+     * @ 테스트
+     */
+    @PostMapping("/attachment")
+    public Attachment uploadFile(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("folder") String folder) throws IOException {
+        return attachmentService.saveAttachment(file, folder);
+    }
+
+    /**
+     * @param filePath
+     * @ 테스트
+     */
+    @DeleteMapping("/attachment")
+    public void uploadFile(@RequestParam("filePath") String filePath) {
+        attachmentService.deleteAttachment(filePath);
+    }
+}

--- a/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
@@ -1,9 +1,7 @@
 package com.edio.studywithcard.attachment.domain;
 
 import com.edio.common.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -37,4 +35,8 @@ public class Attachment extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private boolean isShared = false;
+
+    @ManyToOne
+    @JoinColumn(name = "attachment_deck_target_id", nullable = false)
+    private AttachmentDeckTarget attachmentDeckTarget;
 }

--- a/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
@@ -4,6 +4,9 @@ import com.edio.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "attachment")
 @Getter
@@ -36,7 +39,6 @@ public class Attachment extends BaseEntity {
     @Builder.Default
     private boolean isShared = false;
 
-    @ManyToOne
-    @JoinColumn(name = "attachment_deck_target_id", nullable = false)
-    private AttachmentDeckTarget attachmentDeckTarget;
+    @OneToMany(mappedBy = "attachment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AttachmentDeckTarget> attachmentDeckTargets = new ArrayList<>();
 }

--- a/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/Attachment.java
@@ -1,0 +1,40 @@
+package com.edio.studywithcard.attachment.domain;
+
+import com.edio.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "attachment")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Attachment extends BaseEntity {
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String fileType;
+
+    @Column(nullable = false)
+    private String filePath;
+
+    @Column(nullable = false)
+    private String fileSize;
+
+    @Column(nullable = false)
+    private String fileTarget;
+
+    @Column(nullable = false)
+    @Builder.Default
+    @Setter
+    private boolean isDeleted = false;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isShared = false;
+}

--- a/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
@@ -3,6 +3,9 @@ package com.edio.studywithcard.attachment.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "attachment_deck_target")
 @Getter
@@ -14,5 +17,8 @@ public class AttachmentDeckTarget {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
+    @OneToMany(mappedBy = "attachmentDeckTarget", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Attachment> attachments = new ArrayList<>();
 }

--- a/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
@@ -1,0 +1,18 @@
+package com.edio.studywithcard.attachment.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "attachment_deck_target")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class AttachmentDeckTarget {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+}

--- a/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
@@ -1,5 +1,6 @@
 package com.edio.studywithcard.attachment.domain;
 
+import com.edio.studywithcard.deck.domain.Deck;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,6 +15,10 @@ public class AttachmentDeckTarget {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "deck_id")
+    private Deck deck;
 
     @ManyToOne
     @JoinColumn(name = "attachment_id")

--- a/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
+++ b/src/main/java/com/edio/studywithcard/attachment/domain/AttachmentDeckTarget.java
@@ -3,9 +3,6 @@ package com.edio.studywithcard.attachment.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Table(name = "attachment_deck_target")
 @Getter
@@ -18,7 +15,7 @@ public class AttachmentDeckTarget {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "attachmentDeckTarget", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Attachment> attachments = new ArrayList<>();
+    @ManyToOne
+    @JoinColumn(name = "attachment_id")
+    private Attachment attachment;
 }

--- a/src/main/java/com/edio/studywithcard/attachment/repository/AttachmentDeckTargetRepository.java
+++ b/src/main/java/com/edio/studywithcard/attachment/repository/AttachmentDeckTargetRepository.java
@@ -1,0 +1,7 @@
+package com.edio.studywithcard.attachment.repository;
+
+import com.edio.studywithcard.attachment.domain.AttachmentDeckTarget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttachmentDeckTargetRepository extends JpaRepository<AttachmentDeckTarget, Long> {
+}

--- a/src/main/java/com/edio/studywithcard/attachment/repository/AttachmentRepository.java
+++ b/src/main/java/com/edio/studywithcard/attachment/repository/AttachmentRepository.java
@@ -1,0 +1,10 @@
+package com.edio.studywithcard.attachment.repository;
+
+import com.edio.studywithcard.attachment.domain.Attachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
+    Optional<Attachment> findByFilePathAndIsDeletedFalse(String filePath);
+}

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
@@ -1,0 +1,12 @@
+package com.edio.studywithcard.attachment.service;
+
+import com.edio.studywithcard.attachment.domain.Attachment;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface AttachmentService {
+    Attachment saveAttachment(MultipartFile file, String folder) throws IOException;
+
+    void deleteAttachment(String filePath);
+}

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -2,6 +2,8 @@ package com.edio.studywithcard.attachment.service;
 
 import com.edio.common.exception.NotFoundException;
 import com.edio.studywithcard.attachment.domain.Attachment;
+import com.edio.studywithcard.attachment.domain.AttachmentDeckTarget;
+import com.edio.studywithcard.attachment.repository.AttachmentDeckTargetRepository;
 import com.edio.studywithcard.attachment.repository.AttachmentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +17,10 @@ import org.springframework.web.multipart.MultipartFile;
 public class AttachmentServiceImpl implements AttachmentService {
 
     private final S3Service s3Service;
+
     private final AttachmentRepository attachmentRepository;
+
+    private final AttachmentDeckTargetRepository attachmentDeckTargetRepository;
 
     /*
         파일 업로드 및 저장
@@ -27,14 +32,22 @@ public class AttachmentServiceImpl implements AttachmentService {
         String filePath = s3Service.uploadFile(file, folder);
 
         // 2. DB 저장
+        // FIXME: fileTarget을 제대로 된 값으로 수정
         Attachment attachment = Attachment.builder()
                 .fileName(file.getOriginalFilename())
                 .filePath(filePath)
                 .fileSize(convertFileSize(file.getSize()))
                 .fileType(file.getContentType())
-                .fileTarget("test")
+                .fileTarget("deck")
                 .build();
-        return attachmentRepository.save(attachment);
+        attachment = attachmentRepository.save(attachment);
+
+        AttachmentDeckTarget attachmentDeckTarget = AttachmentDeckTarget.builder()
+                .attachment(attachment)
+                .build();
+        attachmentDeckTargetRepository.save(attachmentDeckTarget);
+
+        return attachment;
     }
 
     /*
@@ -63,3 +76,4 @@ public class AttachmentServiceImpl implements AttachmentService {
         }
     }
 }
+

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -1,0 +1,65 @@
+package com.edio.studywithcard.attachment.service;
+
+import com.edio.common.exception.NotFoundException;
+import com.edio.studywithcard.attachment.domain.Attachment;
+import com.edio.studywithcard.attachment.repository.AttachmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AttachmentServiceImpl implements AttachmentService {
+
+    private final S3Service s3Service;
+    private final AttachmentRepository attachmentRepository;
+
+    /*
+        파일 업로드 및 저장
+     */
+    @Override
+    @Transactional
+    public Attachment saveAttachment(MultipartFile file, String folder) {
+        // 1. S3 업로드
+        String filePath = s3Service.uploadFile(file, folder);
+
+        // 2. DB 저장
+        Attachment attachment = Attachment.builder()
+                .fileName(file.getOriginalFilename())
+                .filePath(filePath)
+                .fileSize(convertFileSize(file.getSize()))
+                .fileType(file.getContentType())
+                .fileTarget("test")
+                .build();
+        return attachmentRepository.save(attachment);
+    }
+
+    /*
+        파일 삭제
+     */
+    @Override
+    @Transactional
+    public void deleteAttachment(String filePath) {
+        Attachment existingAttachment = attachmentRepository.findByFilePathAndIsDeletedFalse(filePath)
+                .orElseThrow(() -> new NotFoundException(Attachment.class, filePath));
+
+        existingAttachment.setDeleted(true);
+
+        s3Service.deleteFile(filePath);
+    }
+
+    public static String convertFileSize(long sizeInBytes) {
+        if (sizeInBytes < 1024) {
+            return sizeInBytes + " B";
+        } else if (sizeInBytes < 1024 * 1024) {
+            return String.format("%.2f KB", sizeInBytes / 1024.0);
+        } else if (sizeInBytes < 1024 * 1024 * 1024) {
+            return String.format("%.2f MB", sizeInBytes / (1024.0 * 1024.0));
+        } else {
+            return String.format("%.2f GB", sizeInBytes / (1024.0 * 1024.0 * 1024.0));
+        }
+    }
+}

--- a/src/main/java/com/edio/studywithcard/attachment/service/S3Service.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/S3Service.java
@@ -1,0 +1,9 @@
+package com.edio.studywithcard.attachment.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+    String uploadFile(MultipartFile file, String folder);
+
+    void deleteFile(String filePath);
+}

--- a/src/main/java/com/edio/studywithcard/attachment/service/S3ServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/S3ServiceImpl.java
@@ -42,13 +42,13 @@ public class S3ServiceImpl implements S3Service {
             );
         } catch (IOException e) {
             log.error("로컬 파일 처리 중 오류 발생: {}", e.getMessage(), e);
-            throw new InternalServerException(S3ServiceImpl.class, fileName);
+            throw new InternalServerException(e.getMessage());
         } catch (AwsServiceException e) {
             log.error("AWS S3 서비스 오류 발생: {}", e.getMessage(), e);
-            throw new InternalServerException(S3ServiceImpl.class, fileName);
+            throw new InternalServerException(e.getMessage());
         } catch (SdkClientException e) {
             log.error("AWS S3 업로드 중 클라이언트 오류 발생: {}", e.getMessage(), e);
-            throw new InternalServerException(S3ServiceImpl.class, fileName);
+            throw new InternalServerException(e.getMessage());
         }
         return fileName;
     }
@@ -67,13 +67,13 @@ public class S3ServiceImpl implements S3Service {
             );
         } catch (AwsServiceException e) {
             log.error("AWS 서비스 오류 발생 - 파일 삭제 실패: {}", filePath, e);
-            throw new InternalServerException(S3ServiceImpl.class, filePath);
+            throw new InternalServerException(e.getMessage());
         } catch (SdkClientException e) {
             log.error("AWS 클라이언트 오류 발생 - 파일 삭제 실패: {}", filePath, e);
-            throw new InternalServerException(S3ServiceImpl.class, filePath);
+            throw new InternalServerException(e.getMessage());
         } catch (Exception e) {
             log.error("알 수 없는 오류 발생 - 파일 삭제 실패: {}", filePath, e);
-            throw new InternalServerException(S3ServiceImpl.class, filePath);
+            throw new InternalServerException(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/edio/studywithcard/attachment/service/S3ServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/S3ServiceImpl.java
@@ -1,0 +1,79 @@
+package com.edio.studywithcard.attachment.service;
+
+import com.edio.common.exception.InternalServerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+    private final S3Client s3Client;
+
+    private final String bucketName = System.getProperty("AWS_BUCKET_NAME");
+
+    /*
+        파일 업로드
+     */
+    @Override
+    public String uploadFile(MultipartFile file, String folder) {
+        // 고유 파일명 생성
+        String fileName = folder + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        try {
+            // S3에 업로드
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(fileName)
+                            .contentType(file.getContentType())
+                            .build(),
+                    RequestBody.fromBytes(file.getBytes())
+            );
+        } catch (IOException e) {
+            log.error("로컬 파일 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new InternalServerException(S3ServiceImpl.class, fileName);
+        } catch (AwsServiceException e) {
+            log.error("AWS S3 서비스 오류 발생: {}", e.getMessage(), e);
+            throw new InternalServerException(S3ServiceImpl.class, fileName);
+        } catch (SdkClientException e) {
+            log.error("AWS S3 업로드 중 클라이언트 오류 발생: {}", e.getMessage(), e);
+            throw new InternalServerException(S3ServiceImpl.class, fileName);
+        }
+        return fileName;
+    }
+
+    /*
+        파일 삭제
+     */
+    @Override
+    public void deleteFile(String filePath) {
+        try {
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(filePath)
+                            .build()
+            );
+        } catch (AwsServiceException e) {
+            log.error("AWS 서비스 오류 발생 - 파일 삭제 실패: {}", filePath, e);
+            throw new InternalServerException(S3ServiceImpl.class, filePath);
+        } catch (SdkClientException e) {
+            log.error("AWS 클라이언트 오류 발생 - 파일 삭제 실패: {}", filePath, e);
+            throw new InternalServerException(S3ServiceImpl.class, filePath);
+        } catch (Exception e) {
+            log.error("알 수 없는 오류 발생 - 파일 삭제 실패: {}", filePath, e);
+            throw new InternalServerException(S3ServiceImpl.class, filePath);
+        }
+    }
+}


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- 첨부 파일 관리를 위해 AWS S3에 Bucket(edio-file-bucket) 및 IAM(access, secret key) 추가
- S3에 파일 업로드 및 삭제 API 개발(구조만 짜고 추후에 Deck과 연관 지어서 리팩토링 예정)
- Controller에 있는 API는 테스트를 위해 추후 삭제 예정
- 기본 구조 main에 병합 후, deck, attachment_deck_target, attachment 연관 동작 기능 개발 예정

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before
🏡 after
![스크린샷 2024-12-12 190038](https://github.com/user-attachments/assets/48ec4cc0-e100-49b6-b03f-e7f348728cb7)

