### PR TITLE
[fix] #69 Swagger 내 API 호출 URL 변경

### DIFF
--- a/src/main/java/com/edio/common/config/SwaggerConfig.java
+++ b/src/main/java/com/edio/common/config/SwaggerConfig.java
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
         ),
         security = @SecurityRequirement(name = "bearerAuth"),
         servers = {
-                @Server(url = "https://ec2-3-38-251-128.ap-northeast-2.compute.amazonaws.com",
+                @Server(url = "/",
                         description = "서버 URL"),
         }
 )


### PR DESCRIPTION
- ec2 고정에서 현재 구동 서버를 기반으로 호출하도록 변경

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Swagger 에서 ec2 고정 호출 URL에서 현재 구동 서버를 기반으로 호출하도록 변경


### 📝 Checklist

Swagger 확인
closes #69 
- [ ] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

🌱 before

![image](https://github.com/user-attachments/assets/3aebe51d-b66d-4863-8042-6a6349e783bd)

🏡 after

![image](https://github.com/user-attachments/assets/1cba0c77-3246-404d-9e50-8a7ce1283668)
