### PR TITLE
Add: Swagger JSON/Multipart 동시 요청 처리를 위한 SwaggerBody 인터페이스 생성 및 적용

### DIFF
--- a/src/main/java/com/edio/common/config/SwaggerBody.java
+++ b/src/main/java/com/edio/common/config/SwaggerBody.java
@@ -1,0 +1,33 @@
+package com.edio.common.config;
+
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@RequestBody
+@Inherited
+public @interface SwaggerBody {
+
+    @AliasFor(annotation = RequestBody.class)
+    String description() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    Content[] content() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean required() default false;
+
+    @AliasFor(annotation = RequestBody.class)
+    Extension[] extensions() default {};
+
+    @AliasFor(annotation = RequestBody.class)
+    String ref() default "";
+
+    @AliasFor(annotation = RequestBody.class)
+    boolean useParameterTypeSchema() default false;
+}

--- a/src/main/java/com/edio/studywithcard/deck/controller/DeckController.java
+++ b/src/main/java/com/edio/studywithcard/deck/controller/DeckController.java
@@ -1,5 +1,6 @@
 package com.edio.studywithcard.deck.controller;
 
+import com.edio.common.config.SwaggerBody;
 import com.edio.common.model.response.SwaggerCommonResponses;
 import com.edio.studywithcard.deck.model.request.DeckCreateRequest;
 import com.edio.studywithcard.deck.model.request.DeckDeleteRequest;
@@ -8,6 +9,8 @@ import com.edio.studywithcard.deck.model.request.DeckUpdateRequest;
 import com.edio.studywithcard.deck.model.response.DeckResponse;
 import com.edio.studywithcard.deck.service.DeckService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +45,7 @@ public class DeckController {
      * @param file
      * @return 등록한 Deck의 상세 정보
      */
+    @SwaggerBody(content = @Content(encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
     @PostMapping(value = "/deck", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Deck 등록", description = "Deck을 등록합니다.")
     public DeckResponse createDeck(@RequestPart DeckCreateRequest request,
@@ -53,6 +57,7 @@ public class DeckController {
      * @param request (id, categoryId, name, description) 수정할 Deck 객체
      * @param file
      */
+    @SwaggerBody(content = @Content(encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
     @PatchMapping(value = "/deck", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Deck 수정", description = "Deck을 수정합니다.")
     public void updateDeck(@RequestPart DeckUpdateRequest request,

--- a/src/main/java/com/edio/studywithcard/deck/model/request/DeckCreateRequest.java
+++ b/src/main/java/com/edio/studywithcard/deck/model/request/DeckCreateRequest.java
@@ -1,5 +1,16 @@
 package com.edio.studywithcard.deck.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Deck 생성 요청 정보", example = """
+        {
+          "folderId": 1,
+          "categoryId": 1,
+          "name": "Deck Name",
+          "description": "Deck Description",
+          "isShared": false
+        }
+        """)
 public record DeckCreateRequest(
         Long folderId,
         Long categoryId,

--- a/src/main/java/com/edio/studywithcard/deck/model/request/DeckDeleteRequest.java
+++ b/src/main/java/com/edio/studywithcard/deck/model/request/DeckDeleteRequest.java
@@ -1,5 +1,12 @@
 package com.edio.studywithcard.deck.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Deck 삭제 요청 정보", example = """
+        {
+          "id": 1
+        }
+        """)
 public record DeckDeleteRequest(
         Long id
 ) {

--- a/src/main/java/com/edio/studywithcard/deck/model/request/DeckMoveRequest.java
+++ b/src/main/java/com/edio/studywithcard/deck/model/request/DeckMoveRequest.java
@@ -1,5 +1,13 @@
 package com.edio.studywithcard.deck.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Deck 이동 요청 정보", example = """
+        {
+          "id": 1,
+          "parentId": 2
+        }
+        """)
 public record DeckMoveRequest(
         Long id,
         Long parentId

--- a/src/main/java/com/edio/studywithcard/deck/model/request/DeckUpdateRequest.java
+++ b/src/main/java/com/edio/studywithcard/deck/model/request/DeckUpdateRequest.java
@@ -1,5 +1,16 @@
 package com.edio.studywithcard.deck.model.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Deck 수정 요청 정보", example = """
+        {
+          "id": 1,
+          "categoryId": 1,
+          "name": "Deck Update Name",
+          "description": "Deck Update Description",
+          "isFavorite" : false
+        }
+        """)
 public record DeckUpdateRequest(
         Long id,
         Long categoryId,


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- Swagger에서 제공하는 RequestBody는 기존 어노테이션과 충돌하기 때문에 SwaggerBody를 따로 생성
- request 객체 요청에 대해서는 application/json 요청으로 처리되도록 설정
- model 패키지의 request객체들에 schema 설정으로 example 설정
- 현재는 Deck만 적용, approve되면 나머지 multipart 부분도 적용 예정

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
