### PR TITLE
feat/ JwtAuthenticationFilter 내부 Exception 응답 처리(401)

### DIFF
--- a/src/main/java/com/edio/common/exception/base/ErrorMessages.java
+++ b/src/main/java/com/edio/common/exception/base/ErrorMessages.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 public enum ErrorMessages {
     BAD_REQUEST("E400-001", "Invalid Request"), // IllegalArgumentException
 
-    TOKEN_EXPIRED("E401-001", "Token Invalid or Expired"), // BadCredentialsException
-    AUTHENTICATION_FAILED("E401-002", "Authentication Failed"), // AuthenticationException
+    TOKEN_EXPIRED("E401-001", "Token Expired"), // BadCredentialsException
+    TOKEN_INVALID("E401-002", "Token Invalid"),
+    AUTHENTICATION_FAILED("E401-003", "Authentication Failed"), // AuthenticationException
 
     INVALID_CSRF_TOKEN("E403-001", "Invalid CSRF Token"), // AccessDeniedException
 

--- a/src/main/java/com/edio/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/edio/common/security/jwt/JwtTokenProvider.java
@@ -74,15 +74,16 @@ public class JwtTokenProvider {
             String loginId = claims.getSubject();
 
             // 필수 클레임이 존재하는지 확인
-            Object authClaim = claims.get(CLAIM_AUTHORITY);
-            if (authClaim == null) {
+            String authClaim = claims.get(CLAIM_AUTHORITY, String.class);
+
+            if (authClaim == null || authClaim.trim().isEmpty()) {
                 throw new InsufficientAuthenticationException(ErrorMessages.TOKEN_INVALID.getMessage());
             }
 
             // UserDetails에서 CustomUserDetails 반환
             CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(loginId);
 
-            Collection<? extends GrantedAuthority> authorities = Arrays.stream(authClaim.toString().split(","))
+            Collection<? extends GrantedAuthority> authorities = Arrays.stream(authClaim.split(","))
                     .map(SimpleGrantedAuthority::new)
                     .collect(Collectors.toList());
 

--- a/src/test/java/com/edio/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/edio/common/security/jwt/JwtTokenProviderTest.java
@@ -6,6 +6,8 @@ import com.edio.common.security.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.security.Key;
 import java.util.Collections;
 import java.util.Date;
 
@@ -53,9 +56,12 @@ class JwtTokenProviderTest {
         if (expiration != null) {
             claims.setExpiration(expiration);
         }
+
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        Key key = Keys.hmacShaKeyFor(keyBytes);
         return Jwts.builder()
                 .setClaims(claims)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/src/test/java/com/edio/common/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/edio/common/security/jwt/JwtTokenProviderTest.java
@@ -79,7 +79,7 @@ class JwtTokenProviderTest {
         String invalidToken = "invalid.token.value";
 
         // when & then
-        assertThrows(io.jsonwebtoken.MalformedJwtException.class,
+        assertThrows(org.springframework.security.authentication.InsufficientAuthenticationException.class,
                 () -> jwtTokenProvider.getAuthentication(invalidToken));
     }
 
@@ -96,7 +96,7 @@ class JwtTokenProviderTest {
                 .compact();
 
         // when & then
-        assertThrows(org.springframework.security.authentication.BadCredentialsException.class,
+        assertThrows(org.springframework.security.authentication.InsufficientAuthenticationException.class,
                 () -> jwtTokenProvider.getAuthentication(expiredToken));
     }
 }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### JWTAuthenticationFilter에서의 Exception 오류 발생 시나리오
- Filter 순서를 크게 보면 JwtAuthenticationFilter -> OAuth2AuthorizationRequestRedirectFilter -> UsernamePasswordAuthenticationFilter -> ExceptionTranslationFilter 순서로 동작함
- Spring Filter Chain에서 발생한 예외는 ExceptionTranlationFilter가 감지하고 AuthenticationEntryPoint로 전달 가능
- 하지만, 기존 코드는 JwtAuthenticationFilter에서 exception을 throw해주고 있었기 때문에 ExceptionTranlationFilter까지 도달하지 못함
- 이를 해결하기 위해, 적절한 Exception발생 시 예외를 바로 throw해주는 것이 아닌 doFilter를 통해 다음 필터로 넘겨주어 정상적으로 EntryPoint로 응답해줄 수 있도록 수정

### 수정 후 시나리오
1. JwtAuthenticationFilter에서 예외 발생
2. catch에서 throw가 아닌 doFilter로 예외 전달
3. OAuth2에 대한 동작 요청이 아니기때문에 OAuth2AuthorizationRequestRedirectFilter 다음 필터인 ExceptionTranslationFilter로 정상적으로 전달
4. EntryPoint를 통해 401 응답

### 수정 내용
- Provider에서 적절한 예외를 JwtFilter로 전달하도록 수정
- Provider 로직 리팩토링(토큰 생성 메서드 분리, try-catch 사용 개선)
- JwtFilter에 try-catch를 통해 ExceptionTranlationFilter로 정상 전달
- 기존에 사용하던 BadCredentialException은 로그인시 아이디/비밀번호 불일치와 같은 상황에 사용하기 때문에 Jwt 검증에는 AuthenticationException 하위의 InsufficientAuthenticationException가 더 적절

#91 
### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
