### PR TITLE
feat/ #93 카드 등록/수정 API Refactor

### DIFF
--- a/src/main/java/com/edio/common/aop/EntityNotFoundAspect.java
+++ b/src/main/java/com/edio/common/aop/EntityNotFoundAspect.java
@@ -1,0 +1,35 @@
+package com.edio.common.aop;
+
+import com.edio.common.exception.base.ErrorMessages;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Aspect
+@Component
+@Order(1) // AOP 실행 우선순위 설정
+@Slf4j
+public class EntityNotFoundAspect {
+
+    @Around("execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..)) && " +
+            "execution(* *.findById*(..))")
+    public Object handleFindById(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = joinPoint.proceed(); // findById.. 실행
+
+        if (result instanceof Optional<?> optional && optional.isEmpty()) { // 패턴 매칭 적용
+            Object id = joinPoint.getArgs().length > 0 ? joinPoint.getArgs()[0] : "Unknown";
+            String entityName = joinPoint.getSignature().getDeclaringType().getSimpleName();
+            entityName = entityName.replace("Repository", "");
+
+            log.warn("{} Not Found with ID: {}", entityName, id);
+            throw new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(entityName, id));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/edio/common/exception/base/ErrorMessages.java
+++ b/src/main/java/com/edio/common/exception/base/ErrorMessages.java
@@ -13,6 +13,7 @@ public enum ErrorMessages {
     AUTHENTICATION_FAILED("E401-003", "Authentication Failed"), // AuthenticationException
 
     INVALID_CSRF_TOKEN("E403-001", "Invalid CSRF Token"), // AccessDeniedException
+    FORBIDDEN_NOT_OWNER("E403-002", "Not Resource Owner"), // AccessDeniedException
 
     DATA_NOT_FOUND("E404-001", "Data Not Found"), // NoSuchElementException
     NOT_FOUND_ENTITY("E404-002", "%s Not Found with ID: %s"), // EntityNotFoundException

--- a/src/main/java/com/edio/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/edio/common/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.UnsupportedMediaTypeStatusException;
@@ -27,6 +28,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
         log.error(ERROR_OCCURRED, ex.getMessage());
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * FORBIDDEN 동작(권한이 없는 경우)
+     *
+     * @param ex
+     * @return 403
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<String> handleAccessDeniedException(AccessDeniedException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.FORBIDDEN);
     }
 
     /**

--- a/src/main/java/com/edio/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/edio/common/exception/handler/GlobalExceptionHandler.java
@@ -42,26 +42,13 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * NoSuchElementException
+     * NoSuchElementException, EntityNotFoundException
      *
      * @param ex
      * @return 404
      */
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException ex) {
-        log.error(ERROR_OCCURRED, ex.getMessage());
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
-    }
-
-    /**
-     * EntityNotFoundException (명시적 호출)
-     *
-     * @param ex
-     * @return 404
-     */
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<String> handleEntityNotFoundException(EntityNotFoundException ex) {
-        log.error(ERROR_OCCURRED, ex.getMessage());
+    @ExceptionHandler({NoSuchElementException.class, EntityNotFoundException.class})
+    public ResponseEntity<String> handleNotFoundExceptions(RuntimeException ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
@@ -1,7 +1,6 @@
 package com.edio.studywithcard.attachment.service;
 
 import com.edio.studywithcard.attachment.domain.Attachment;
-import com.edio.studywithcard.card.domain.Card;
 import com.edio.studywithcard.card.dto.AttachmentBulkData;
 import com.edio.studywithcard.deck.domain.Deck;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,7 +20,4 @@ public interface AttachmentService {
 
     // 첨부 파일 삭제(Bulk)
     void deleteAllAttachments(List<String> fileKeys);
-
-    // 첨부 파일 삭제(단일)
-    void deleteAttachment(String fileKey);
 }

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
@@ -2,6 +2,7 @@ package com.edio.studywithcard.attachment.service;
 
 import com.edio.studywithcard.attachment.domain.Attachment;
 import com.edio.studywithcard.card.domain.Card;
+import com.edio.studywithcard.card.dto.AttachmentBulkData;
 import com.edio.studywithcard.deck.domain.Deck;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -11,6 +12,9 @@ import java.util.List;
 public interface AttachmentService {
     // 첨부 파일 저장
     Attachment saveAttachment(MultipartFile file, String folder, String target) throws IOException;
+
+    // 첨부 파일 저장(Bulk)
+    void saveAllAttachments(List<AttachmentBulkData> bulkDataList);
 
     // Deck 중간 테이블 저장
     void saveAttachmentDeckTarget(Attachment attachment, Deck deck);

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
@@ -19,9 +19,6 @@ public interface AttachmentService {
     // Deck 중간 테이블 저장
     void saveAttachmentDeckTarget(Attachment attachment, Deck deck);
 
-    // Card 중간 테이블 저장
-    void saveAttachmentCardTarget(Attachment attachment, Card card);
-
     // 첨부 파일 삭제(Bulk)
     void deleteAllAttachments(List<String> fileKeys);
 

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentService.java
@@ -20,4 +20,7 @@ public interface AttachmentService {
 
     // 첨부 파일 삭제(Bulk)
     void deleteAllAttachments(List<String> fileKeys);
+
+    // 첨부 파일 삭제(단일)
+    void deleteAttachment(String fileKey);
 }

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -1,6 +1,5 @@
 package com.edio.studywithcard.attachment.service;
 
-import com.edio.common.exception.base.ErrorMessages;
 import com.edio.studywithcard.attachment.domain.Attachment;
 import com.edio.studywithcard.attachment.domain.AttachmentCardTarget;
 import com.edio.studywithcard.attachment.domain.AttachmentDeckTarget;
@@ -11,7 +10,6 @@ import com.edio.studywithcard.attachment.repository.AttachmentRepository;
 import com.edio.studywithcard.card.domain.Card;
 import com.edio.studywithcard.card.dto.AttachmentBulkData;
 import com.edio.studywithcard.deck.domain.Deck;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.util.Pair;
@@ -126,21 +124,5 @@ public class AttachmentServiceImpl implements AttachmentService {
 
         // 2. S3에서 파일 삭제
         s3Service.deleteFiles(fileKeys);
-    }
-
-    /*
-        단일 파일 삭제
-    */
-    @Override
-    @Transactional
-    public void deleteAttachment(String fileKey) {
-        // 1. DB에서 해당 파일을 삭제 처리
-        Attachment attachment = attachmentRepository.findByFileKeyAndIsDeletedFalse(fileKey)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Attachment.class.getSimpleName(), fileKey)));
-
-        attachment.setDeleted(true);
-
-        // 2. S3에서 파일 삭제
-        s3Service.deleteFile(fileKey);
     }
 }

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.edio.studywithcard.attachment.service;
 
+import com.edio.common.exception.base.ErrorMessages;
 import com.edio.studywithcard.attachment.domain.Attachment;
 import com.edio.studywithcard.attachment.domain.AttachmentCardTarget;
 import com.edio.studywithcard.attachment.domain.AttachmentDeckTarget;
@@ -9,6 +10,7 @@ import com.edio.studywithcard.attachment.repository.AttachmentDeckTargetReposito
 import com.edio.studywithcard.attachment.repository.AttachmentRepository;
 import com.edio.studywithcard.card.domain.Card;
 import com.edio.studywithcard.deck.domain.Deck;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -79,7 +81,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     }
 
     /*
-        파일 삭제
+        다중 파일 삭제
      */
     @Override
     @Transactional
@@ -90,5 +92,21 @@ public class AttachmentServiceImpl implements AttachmentService {
 
         // 2. S3에서 파일 삭제
         s3Service.deleteFiles(fileKeys);
+    }
+
+    /*
+        단일 파일 삭제
+    */
+    @Override
+    @Transactional
+    public void deleteAttachment(String fileKey) {
+        // 1. DB에서 해당 파일을 삭제 처리
+        Attachment attachment = attachmentRepository.findByFileKeyAndIsDeletedFalse(fileKey)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Attachment.class.getSimpleName(), fileKey)));
+
+        attachment.setDeleted(true);
+
+        // 2. S3에서 파일 삭제
+        s3Service.deleteFile(fileKey);
     }
 }

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -9,14 +9,17 @@ import com.edio.studywithcard.attachment.repository.AttachmentCardTargetReposito
 import com.edio.studywithcard.attachment.repository.AttachmentDeckTargetRepository;
 import com.edio.studywithcard.attachment.repository.AttachmentRepository;
 import com.edio.studywithcard.card.domain.Card;
+import com.edio.studywithcard.card.dto.AttachmentBulkData;
 import com.edio.studywithcard.deck.domain.Deck;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -31,6 +34,48 @@ public class AttachmentServiceImpl implements AttachmentService {
     private final AttachmentDeckTargetRepository attachmentDeckTargetRepository;
 
     private final AttachmentCardTargetRepository attachmentCardTargetRepository;
+
+    /*
+        S3 업로드 및 Attachment/AttachmentCardTarget 객체를 벌크로 생성하고 저장하는 메서드
+    */
+    @Override
+    @Transactional
+    public void saveAllAttachments(List<AttachmentBulkData> bulkDataList) {
+        // 병렬 스트림을 사용하여 각 파일에 대해 S3 업로드 및 Attachment 객체 생성
+        List<Pair<Attachment, Card>> attachmentCardPairs = bulkDataList.parallelStream()
+                .map(data -> {
+                    // S3 업로드
+                    FileInfoResponse fileInfo = s3Service.uploadFile(data.getFile(), data.getFolder().toLowerCase());
+
+                    // Attachment 객체 생성
+                    Attachment attachment = Attachment.builder()
+                            .fileName(data.getFile().getOriginalFilename())
+                            .fileKey(fileInfo.fileKey())
+                            .filePath(fileInfo.filePath())
+                            .fileSize(data.getFile().getSize())
+                            .fileType(data.getFile().getContentType())
+                            .fileTarget(data.getTarget())
+                            .build();
+                    return Pair.of(attachment, data.getCard());
+                })
+                .toList();
+
+        // Attachment 및 AttachmentCardTarget 객체 리스트 생성
+        List<Attachment> attachments = new ArrayList<>();
+        List<AttachmentCardTarget> attachmentCardTargets = new ArrayList<>();
+        for (Pair<Attachment, Card> pair : attachmentCardPairs) {
+            attachments.add(pair.getFirst());
+            AttachmentCardTarget attachmentCardTarget = AttachmentCardTarget.builder()
+                    .attachment(pair.getFirst())
+                    .card(pair.getSecond())
+                    .build();
+            attachmentCardTargets.add(attachmentCardTarget);
+        }
+
+        // DB에 벌크 저장 (saveAll 메서드를 사용)
+        attachmentRepository.saveAll(attachments);
+        attachmentCardTargetRepository.saveAll(attachmentCardTargets);
+    }
 
     /*
         파일 업로드 및 Attachment 저장

--- a/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/AttachmentServiceImpl.java
@@ -74,11 +74,13 @@ public class AttachmentServiceImpl implements AttachmentService {
 
         // DB에 벌크 저장 (saveAll 메서드를 사용)
         attachmentRepository.saveAll(attachments);
+
+        // AttachmentCardTarget 저장
         attachmentCardTargetRepository.saveAll(attachmentCardTargets);
     }
 
     /*
-        파일 업로드 및 Attachment 저장
+        파일 업로드 및 Attachment 저장 (Deck에서 사용)
      */
     @Override
     @Transactional
@@ -100,7 +102,7 @@ public class AttachmentServiceImpl implements AttachmentService {
     }
 
     /*
-        AttachmentDeckTarget 저장
+        AttachmentDeckTarget 저장 (Deck에서 사용)
     */
     @Override
     @Transactional
@@ -110,19 +112,6 @@ public class AttachmentServiceImpl implements AttachmentService {
                 .deck(deck)
                 .build();
         attachmentDeckTargetRepository.save(attachmentDeckTarget);
-    }
-
-    /*
-        AttachmentCardTarget 저장
-    */
-    @Override
-    @Transactional
-    public void saveAttachmentCardTarget(Attachment attachment, Card card) {
-        AttachmentCardTarget attachmentCardTarget = AttachmentCardTarget.builder()
-                .attachment(attachment)
-                .card(card)
-                .build();
-        attachmentCardTargetRepository.save(attachmentCardTarget);
     }
 
     /*

--- a/src/main/java/com/edio/studywithcard/attachment/service/S3Service.java
+++ b/src/main/java/com/edio/studywithcard/attachment/service/S3Service.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public interface S3Service {
     FileInfoResponse uploadFile(MultipartFile file, String folder);
-    
+
     void deleteFiles(List<String> fileKeys);
+
+    void deleteFile(String fileKey);
 }

--- a/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
@@ -3,11 +3,10 @@ package com.edio.studywithcard.card.controller;
 import com.edio.common.model.response.SwaggerCommonResponses;
 import com.edio.common.security.CustomUserDetails;
 import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
+import com.edio.studywithcard.card.model.request.CardsDeleteRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import java.util.List;
 
 @Tag(name = "Card", description = "Card 관련 API")
 @SecurityRequirement(name = "bearerAuth")
@@ -20,8 +19,9 @@ public interface CardApiDoc {
     void createOrUpdateCards(CustomUserDetails userDetails, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     /**
-     * @param request [] 삭제할 Card의 ID 리스트
+     * @param deckId  (deckId)
+     * @param cardIds (cardId List)
      */
-    @Operation(summary = "Cards 삭제", description = "Card를 삭제합니다.")
-    void deleteCards(List<Long> request);
+    @Operation(summary = "Card 삭제", description = "Card를 삭제합니다.")
+    void deleteCards(CustomUserDetails userDetails, CardsDeleteRequest request);
 }

--- a/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
@@ -6,8 +6,6 @@ import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.ModelAttribute;
 
 import java.util.List;
 
@@ -19,8 +17,7 @@ public interface CardApiDoc {
      * @param cardBulkRequestWrapper (cardId, deckId, name, description, files) 등록 or 수정 객체
      */
     @Operation(summary = "Card 등록|수정", description = "Card를 등록하거나 수정합니다.")
-    void createOrUpdateCards(@AuthenticationPrincipal CustomUserDetails userDetails,
-                             @ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper);
+    void createOrUpdateCards(CustomUserDetails userDetails, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     /**
      * @param request [] 삭제할 Card의 ID 리스트

--- a/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
@@ -16,7 +16,7 @@ public interface CardApiDoc {
      * @param cardBulkRequestWrapper (cardId, deckId, name, description, files) 등록 or 수정 객체
      */
     @Operation(summary = "Card 등록|수정", description = "Card를 등록하거나 수정합니다.")
-    void createOrUpdateCards(CustomUserDetails userDetails, CardBulkRequestWrapper cardBulkRequestWrapper);
+    void upsertCards(CustomUserDetails userDetails, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     /**
      * @param request (deckId, cardIds) 덱 ID, 삭제할 카드 ID 리스트

--- a/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
@@ -1,10 +1,12 @@
 package com.edio.studywithcard.card.controller;
 
 import com.edio.common.model.response.SwaggerCommonResponses;
+import com.edio.common.security.CustomUserDetails;
 import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 import java.util.List;
@@ -17,7 +19,8 @@ public interface CardApiDoc {
      * @param cardBulkRequestWrapper (cardId, deckId, name, description, files) 등록 or 수정 객체
      */
     @Operation(summary = "Card 등록|수정", description = "Card를 등록하거나 수정합니다.")
-    void createOrUpdateCards(@ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper);
+    void createOrUpdateCards(@AuthenticationPrincipal CustomUserDetails userDetails,
+                             @ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper);
 
     /**
      * @param request [] 삭제할 Card의 ID 리스트

--- a/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardApiDoc.java
@@ -19,8 +19,7 @@ public interface CardApiDoc {
     void createOrUpdateCards(CustomUserDetails userDetails, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     /**
-     * @param deckId  (deckId)
-     * @param cardIds (cardId List)
+     * @param request (deckId, cardIds) 덱 ID, 삭제할 카드 ID 리스트
      */
     @Operation(summary = "Card 삭제", description = "Card를 삭제합니다.")
     void deleteCards(CustomUserDetails userDetails, CardsDeleteRequest request);

--- a/src/main/java/com/edio/studywithcard/card/controller/CardController.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardController.java
@@ -1,10 +1,12 @@
 package com.edio.studywithcard.card.controller;
 
+import com.edio.common.security.CustomUserDetails;
 import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
 import com.edio.studywithcard.card.service.CardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,8 +21,9 @@ public class CardController implements CardApiDoc {
 
     @PostMapping(value = "/cards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Override
-    public void createOrUpdateCards(@ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper) {
-        cardService.createOrUpdateCards(cardBulkRequestWrapper);
+    public void createOrUpdateCards(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                    @ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper) {
+        cardService.createOrUpdateCards(userDetails.getAccountId(), cardBulkRequestWrapper);
     }
 
     @DeleteMapping("/cards")

--- a/src/main/java/com/edio/studywithcard/card/controller/CardController.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardController.java
@@ -20,7 +20,7 @@ public class CardController implements CardApiDoc {
 
     @PostMapping(value = "/cards", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Override
-    public void createOrUpdateCards(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public void upsertCards(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper) {
         cardService.upsert(userDetails.getAccountId(), cardBulkRequestWrapper);
     }

--- a/src/main/java/com/edio/studywithcard/card/controller/CardController.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardController.java
@@ -23,7 +23,7 @@ public class CardController implements CardApiDoc {
     @Override
     public void createOrUpdateCards(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @ModelAttribute CardBulkRequestWrapper cardBulkRequestWrapper) {
-        cardService.createOrUpdateCards(userDetails.getAccountId(), cardBulkRequestWrapper);
+        cardService.upsert(userDetails.getAccountId(), cardBulkRequestWrapper);
     }
 
     @DeleteMapping("/cards")

--- a/src/main/java/com/edio/studywithcard/card/controller/CardController.java
+++ b/src/main/java/com/edio/studywithcard/card/controller/CardController.java
@@ -2,14 +2,13 @@ package com.edio.studywithcard.card.controller;
 
 import com.edio.common.security.CustomUserDetails;
 import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
+import com.edio.studywithcard.card.model.request.CardsDeleteRequest;
 import com.edio.studywithcard.card.service.CardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -28,7 +27,8 @@ public class CardController implements CardApiDoc {
 
     @DeleteMapping("/cards")
     @Override
-    public void deleteCards(@RequestBody List<Long> request) {
-        cardService.deleteCards(request);
+    public void deleteCards(@AuthenticationPrincipal CustomUserDetails userDetails,
+                            @RequestBody CardsDeleteRequest request) {
+        cardService.deleteCards(userDetails.getAccountId(), request.deckId(), request.cardIds());
     }
 }

--- a/src/main/java/com/edio/studywithcard/card/dto/AttachmentBulkData.java
+++ b/src/main/java/com/edio/studywithcard/card/dto/AttachmentBulkData.java
@@ -1,0 +1,15 @@
+package com.edio.studywithcard.card.dto;
+
+import com.edio.studywithcard.card.domain.Card;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+public class AttachmentBulkData {
+    private MultipartFile file;
+    private Card card;
+    private String folder;
+    private String target;
+}

--- a/src/main/java/com/edio/studywithcard/card/dto/AttachmentBulkData.java
+++ b/src/main/java/com/edio/studywithcard/card/dto/AttachmentBulkData.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AttachmentBulkData {
     private MultipartFile file;
     private Card card;
-    private String folder;
-    private String target;
+    private String folder; // IMAGE, AUDIO
+    private String target; // CARD, DECK
+    private String oldFileKey;
 }

--- a/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
+++ b/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
@@ -23,8 +23,8 @@ public class CardBulkRequest {
                 ", cardId=" + cardId +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", image='" + image + '\'' +
-                ", audio='" + audio + '\'' +
+                ", image='" + (image != null && !image.isEmpty() ? image.getOriginalFilename() : null) + '\'' +
+                ", audio='" + (audio != null && !audio.isEmpty() ? audio.getOriginalFilename() : null) + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
+++ b/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
@@ -23,8 +23,8 @@ public class CardBulkRequest {
                 ", cardId=" + cardId +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", image='" + image.getOriginalFilename() + '\'' +
-                ", audio='" + audio.getOriginalFilename() + '\'' +
+                ", image='" + image + '\'' +
+                ", audio='" + audio + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
+++ b/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
@@ -23,8 +23,8 @@ public class CardBulkRequest {
                 ", cardId=" + cardId +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", image=" + (image != null ? image.getOriginalFilename() : "null") +
-                ", audio=" + (audio != null ? audio.getOriginalFilename() : "null") +
+                ", image='" + image.getOriginalFilename() + '\'' +
+                ", audio='" + audio.getOriginalFilename() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
+++ b/src/main/java/com/edio/studywithcard/card/model/request/CardBulkRequest.java
@@ -3,9 +3,6 @@ package com.edio.studywithcard.card.model.request;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Arrays;
-import java.util.List;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -16,19 +13,18 @@ public class CardBulkRequest {
     private Long cardId;
     private String name;
     private String description;
-    private MultipartFile[] files;
+    private MultipartFile image;
+    private MultipartFile audio;
 
     @Override
     public String toString() {
-        List<String> fileNames = Arrays.stream(files)
-                .map(MultipartFile::getOriginalFilename)
-                .toList();
         return "CardBulkRequest{" +
                 "deckId=" + deckId +
                 ", cardId=" + cardId +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", files=" + fileNames +
+                ", image=" + (image != null ? image.getOriginalFilename() : "null") +
+                ", audio=" + (audio != null ? audio.getOriginalFilename() : "null") +
                 '}';
     }
 }

--- a/src/main/java/com/edio/studywithcard/card/model/request/CardsDeleteRequest.java
+++ b/src/main/java/com/edio/studywithcard/card/model/request/CardsDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.edio.studywithcard.card.model.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "카드 삭제 요청 정보", example = """
+        {
+          "deckId": 1,
+          "cardIds": [1, 2, 3]
+        }
+        """)
+public record CardsDeleteRequest(Long deckId, List<Long> cardIds) {
+}
+

--- a/src/main/java/com/edio/studywithcard/card/service/CardService.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardService.java
@@ -5,7 +5,7 @@ import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
 import java.util.List;
 
 public interface CardService {
-    void createOrUpdateCards(CardBulkRequestWrapper cardBulkRequestWrapper);
+    void createOrUpdateCards(Long accountId, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     void deleteCards(List<Long> request);
 }

--- a/src/main/java/com/edio/studywithcard/card/service/CardService.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardService.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface CardService {
     void upsert(Long accountId, CardBulkRequestWrapper cardBulkRequestWrapper);
 
-    void deleteCards(List<Long> request);
+    void deleteCards(Long accountId, Long deckId, List<Long> cardIds);
 }

--- a/src/main/java/com/edio/studywithcard/card/service/CardService.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardService.java
@@ -5,7 +5,7 @@ import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
 import java.util.List;
 
 public interface CardService {
-    void createOrUpdateCards(Long accountId, CardBulkRequestWrapper cardBulkRequestWrapper);
+    void upsert(Long accountId, CardBulkRequestWrapper cardBulkRequestWrapper);
 
     void deleteCards(List<Long> request);
 }

--- a/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
@@ -85,7 +85,11 @@ public class CardServiceImpl implements CardService {
    */
     @Override
     @Transactional
-    public void deleteCards(List<Long> cardIds) {
+    public void deleteCards(Long accountId, Long deckId, List<Long> cardIds) {
+        // 소유권 검증 수행
+        Deck deck = deckRepository.findById(deckId).orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class.getSimpleName(), deckId)));
+        validateOwnership(accountId, deck);
+
         List<Card> existingCards = cardRepository.findAllById(cardIds).stream()
                 .filter(card -> !card.isDeleted())
                 .toList();

--- a/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
@@ -21,9 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -108,7 +106,7 @@ public class CardServiceImpl implements CardService {
     }
 
     // 카드 생성
-    private void processCardCreate(CardBulkRequest request, List<Card> newCards, List<AttachmentBulkData> newAttachments){
+    private void processCardCreate(CardBulkRequest request, List<Card> newCards, List<AttachmentBulkData> newAttachments) {
         // 신규 카드: 객체만 생성하여 리스트에 추가
         Card card = createCard(request);
         newCards.add(card);
@@ -125,10 +123,7 @@ public class CardServiceImpl implements CardService {
 
     // 카드 수정
     private void processCardUpdate(CardBulkRequest request, List<AttachmentBulkData> updateAttachments) {
-        Card existingCard = cardRepository.findByIdAndIsDeletedFalse(request.getCardId())
-                .orElseThrow(() -> new EntityNotFoundException(
-                        ErrorMessages.NOT_FOUND_ENTITY.format(Card.class.getSimpleName(), request.getCardId())
-                ));
+        Card existingCard = cardRepository.findByIdAndIsDeletedFalse(request.getCardId()).get();
 
         if (StringUtils.hasText(request.getName())) {
             existingCard.setName(request.getName());
@@ -144,10 +139,7 @@ public class CardServiceImpl implements CardService {
 
     // 카드 객체 생성
     private Card createCard(CardBulkRequest request) {
-        Deck deck = deckRepository.findById(request.getDeckId())
-                .orElseThrow(() -> new EntityNotFoundException(
-                        ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class.getSimpleName(), request.getDeckId())
-                ));
+        Deck deck = deckRepository.findById(request.getDeckId()).get();
 
         // Card 객체 생성 (아직 DB에 저장하지 않음)
         return Card.builder()

--- a/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
@@ -116,7 +116,7 @@ public class CardServiceImpl implements CardService {
         newCards.add(card);
 
         // 이미지 첨부파일이 존재하면 벌크 데이터에 추가
-        if (request.getImage() != null && !request.getImage().isEmpty()) {
+        if (!request.getImage().isEmpty()) {
             newAttachments.add(new AttachmentBulkData(
                     request.getImage(), card,
                     AttachmentFolder.IMAGE.name(),
@@ -125,7 +125,7 @@ public class CardServiceImpl implements CardService {
             ));
         }
         // 오디오 첨부파일이 존재하면 벌크 데이터에 추가
-        if (request.getAudio() != null && !request.getAudio().isEmpty()) {
+        if (!request.getAudio().isEmpty()) {
             newAttachments.add(new AttachmentBulkData(
                     request.getAudio(), card,
                     AttachmentFolder.AUDIO.name(),

--- a/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/card/service/CardServiceImpl.java
@@ -194,16 +194,11 @@ public class CardServiceImpl implements CardService {
                 .findFirst()
                 .orElse(null);
 
-        if (file.isEmpty()) {
-            // 빈 파일이면 기존 파일 삭제
-            if (fileKey != null) {
-                attachmentService.deleteAttachment(fileKey);
-            }
-        } else {
-            // 새 파일이 들어오면 기존 파일 삭제 후 저장
-            if (fileKey != null) {
-                attachmentService.deleteAttachment(fileKey);
-            }
+        // 삭제 및 추가
+        if(fileKey != null) {
+            attachmentService.deleteAttachment(fileKey);
+        }
+        if(!file.isEmpty()) {
             try {
                 processAttachment(file, card);
             } catch (IOException e) {

--- a/src/main/java/com/edio/studywithcard/deck/repository/DeckRepository.java
+++ b/src/main/java/com/edio/studywithcard/deck/repository/DeckRepository.java
@@ -2,9 +2,15 @@ package com.edio.studywithcard.deck.repository;
 
 import com.edio.studywithcard.deck.domain.Deck;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DeckRepository extends JpaRepository<Deck, Long> {
     Optional<Deck> findByIdAndIsDeletedFalse(Long id);
+
+    // 소유권 검증을 위한 JPQL
+    @Query("SELECT f.accountId FROM Deck d JOIN d.folder f WHERE d.id = :deckId")
+    Long findAccountIdByDeckId(@Param("deckId") Long deckId);
 }

--- a/src/main/java/com/edio/studywithcard/deck/repository/DeckRepository.java
+++ b/src/main/java/com/edio/studywithcard/deck/repository/DeckRepository.java
@@ -2,15 +2,9 @@ package com.edio.studywithcard.deck.repository;
 
 import com.edio.studywithcard.deck.domain.Deck;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DeckRepository extends JpaRepository<Deck, Long> {
     Optional<Deck> findByIdAndIsDeletedFalse(Long id);
-
-    // 소유권 검증을 위한 JPQL
-    @Query("SELECT f.accountId FROM Deck d JOIN d.folder f WHERE d.id = :deckId")
-    Long findAccountIdByDeckId(@Param("deckId") Long deckId);
 }

--- a/src/main/java/com/edio/studywithcard/deck/service/DeckServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/deck/service/DeckServiceImpl.java
@@ -17,7 +17,6 @@ import com.edio.studywithcard.deck.model.response.DeckResponse;
 import com.edio.studywithcard.deck.repository.DeckRepository;
 import com.edio.studywithcard.folder.domain.Folder;
 import com.edio.studywithcard.folder.repository.FolderRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,8 +47,7 @@ public class DeckServiceImpl implements DeckService {
     @Override
     @Transactional(readOnly = true)
     public DeckResponse getDeck(Long id) {
-        Deck deck = deckRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class.getSimpleName(), id)));
+        Deck deck = deckRepository.findByIdAndIsDeletedFalse(id).get();
         return DeckResponse.from(deck);
     }
 
@@ -61,10 +59,8 @@ public class DeckServiceImpl implements DeckService {
     public DeckResponse createDeck(DeckCreateRequest request, MultipartFile file) {
         try {
             // Folder와 Category를 조회
-            Folder folder = folderRepository.findById(request.folderId())
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class.getSimpleName(), request.folderId())));
-            Category category = categoryRepository.findById(request.categoryId())
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Category.class.getSimpleName(), request.categoryId())));
+            Folder folder = folderRepository.findById(request.folderId()).get();
+            Category category = categoryRepository.findById(request.categoryId()).get();
 
             // 1. Deck 생성 및 저장
             Deck deck = Deck.builder()
@@ -98,8 +94,7 @@ public class DeckServiceImpl implements DeckService {
     @Override
     @Transactional
     public void updateDeck(DeckUpdateRequest request, MultipartFile file) {
-        Deck existingDeck = deckRepository.findByIdAndIsDeletedFalse(request.id())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class.getSimpleName(), request.id())));
+        Deck existingDeck = deckRepository.findByIdAndIsDeletedFalse(request.id()).get();
 
         // 카테고리
         if (request.categoryId() != null) {
@@ -151,8 +146,7 @@ public class DeckServiceImpl implements DeckService {
     @Transactional
     public void moveDeck(DeckMoveRequest request) {
         // 이동할 덱 조회
-        Deck deck = deckRepository.findById(request.id())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class.getSimpleName(), request.id())));
+        Deck deck = deckRepository.findById(request.id()).get();
 
         // 새로운 폴더 조회
         Folder newFolder = null;
@@ -170,8 +164,7 @@ public class DeckServiceImpl implements DeckService {
     @Override
     @Transactional
     public void deleteDeck(DeckDeleteRequest request) {
-        Deck existingDeck = deckRepository.findByIdAndIsDeletedFalse(request.id())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Deck.class, request.id())));
+        Deck existingDeck = deckRepository.findByIdAndIsDeletedFalse(request.id()).get();
 
         // 기존 첨부파일 삭제(Bulk)
         List<String> fileKeys = existingDeck.getAttachmentDeckTargets().stream()

--- a/src/main/java/com/edio/studywithcard/folder/service/FolderServiceImpl.java
+++ b/src/main/java/com/edio/studywithcard/folder/service/FolderServiceImpl.java
@@ -10,7 +10,6 @@ import com.edio.studywithcard.folder.model.response.FolderResponse;
 import com.edio.studywithcard.folder.model.response.FolderWithDeckResponse;
 import com.edio.studywithcard.folder.repository.FolderRepository;
 import com.edio.user.repository.AccountRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,8 +34,7 @@ public class FolderServiceImpl implements FolderService {
     public FolderWithDeckResponse getFolderWithDeck(Long rootFolderId, Long folderId) {
         Long targetFolderId = (folderId == null) ? rootFolderId : folderId;
 
-        Folder folder = folderRepository.findById(targetFolderId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class.getSimpleName(), targetFolderId)));
+        Folder folder = folderRepository.findById(targetFolderId).get();
 
         return FolderWithDeckResponse.from(folder);
     }
@@ -49,8 +47,7 @@ public class FolderServiceImpl implements FolderService {
     public FolderAllResponse getAllFolders(Long rootFolderId, Long folderId) {
         Long targetFolderId = (folderId == null) ? rootFolderId : folderId;
 
-        Folder folder = folderRepository.findById(targetFolderId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class.getSimpleName(), targetFolderId)));
+        Folder folder = folderRepository.findById(targetFolderId).get();
 
         return FolderAllResponse.from(folder);
     }
@@ -97,8 +94,7 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public void updateFolder(Long folderId, FolderUpdateRequest folderUpdateRequest) {
         // 폴더명 업데이트
-        Folder existingFolder = folderRepository.findByIdAndIsDeletedFalse(folderId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class, folderId)));
+        Folder existingFolder = folderRepository.findByIdAndIsDeletedFalse(folderId).get();
 
         existingFolder.setName(folderUpdateRequest.name());
     }
@@ -110,8 +106,7 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public void moveFolder(Long folderId, Long newParentId) {
         // 이동할 폴더 조회
-        Folder folder = folderRepository.findByIdAndIsDeletedFalse(folderId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class.getSimpleName(), folderId)));
+        Folder folder = folderRepository.findByIdAndIsDeletedFalse(folderId).get();
 
         // 새로운 부모 폴더 조회
         Folder newParentFolder = null;
@@ -144,8 +139,7 @@ public class FolderServiceImpl implements FolderService {
     @Override
     @Transactional
     public void deleteFolder(Long folderId) {
-        Folder existingFolder = folderRepository.findByIdAndIsDeletedFalse(folderId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorMessages.NOT_FOUND_ENTITY.format(Folder.class.getSimpleName(), folderId)));
+        Folder existingFolder = folderRepository.findByIdAndIsDeletedFalse(folderId).get();
 
         existingFolder.setDeleted(true);
     }

--- a/src/test/java/com/edio/service/AttachmentServiceTests.java
+++ b/src/test/java/com/edio/service/AttachmentServiceTests.java
@@ -63,7 +63,7 @@ public class AttachmentServiceTests {
         fileKey = "image/test.jpg";
         fileSize = 1024L;
         fileType = "image/jpeg";
-        fileTarget = "DECK";
+        fileTarget = "CARD";
         s3FolderName = "image";
         String filePath = "image/test.jpg";
         String bucketName = "edio-file-bucket";
@@ -114,12 +114,13 @@ public class AttachmentServiceTests {
         List<Attachment> savedAttachments = attachmentsCaptor.getValue();
         assertEquals(1, savedAttachments.size());
         Attachment savedAttachment = savedAttachments.get(0);
-        assertEquals("test.jpg", savedAttachment.getFileName());
+
+        assertEquals(fileName, savedAttachment.getFileName());
         assertEquals(fileInfoResponse.fileKey(), savedAttachment.getFileKey());
         assertEquals(fileInfoResponse.filePath(), savedAttachment.getFilePath());
         assertEquals(mockFile.getSize(), savedAttachment.getFileSize());
         assertEquals(mockFile.getContentType(), savedAttachment.getFileType());
-        assertEquals("CARD", savedAttachment.getFileTarget());
+        assertEquals(bulkData.getTarget(), savedAttachment.getFileTarget());
 
         // AttachmentCardTargetRepository.saveAll 호출 검증: 각 Attachment와 Card 객체가 연결되어 저장되는지 확인
         ArgumentCaptor<List<AttachmentCardTarget>> targetCaptor = ArgumentCaptor.forClass(List.class);
@@ -127,6 +128,7 @@ public class AttachmentServiceTests {
         List<AttachmentCardTarget> savedTargets = targetCaptor.getValue();
         assertEquals(1, savedTargets.size());
         AttachmentCardTarget target = savedTargets.get(0);
+
         assertEquals(dummyCard, target.getCard());
         assertEquals(savedAttachment, target.getAttachment());
     }

--- a/src/test/java/com/edio/service/AttachmentServiceTests.java
+++ b/src/test/java/com/edio/service/AttachmentServiceTests.java
@@ -10,6 +10,7 @@ import com.edio.studywithcard.attachment.repository.AttachmentRepository;
 import com.edio.studywithcard.attachment.service.AttachmentServiceImpl;
 import com.edio.studywithcard.attachment.service.S3Service;
 import com.edio.studywithcard.card.domain.Card;
+import com.edio.studywithcard.card.dto.AttachmentBulkData;
 import com.edio.studywithcard.deck.domain.Deck;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,6 +79,60 @@ public class AttachmentServiceTests {
     }
 
     @Test
+    void testSaveAllAttachments() {
+        // Given
+        // bulkDataList에 들어갈 Dummy 파일과 Card 객체 생성
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                fileName,
+                fileType,
+                new byte[1024]
+        );
+        Card dummyCard = mock(Card.class);
+
+        // bulk 데이터 객체 생성 (업데이트나 신규 모두 같은 방식으로 처리됨)
+        AttachmentBulkData bulkData = new AttachmentBulkData(
+                mockFile,
+                dummyCard,
+                "IMAGE",    // 폴더 (대문자로 저장됨)
+                "CARD",     // 대상
+                null        // 기존 파일 키 (신규 첨부라면 null)
+        );
+        List<AttachmentBulkData> bulkDataList = List.of(bulkData);
+
+        // s3Service.uploadFile stub 설정
+        when(s3Service.uploadFile(any(MultipartFile.class), eq("image")))
+                .thenReturn(fileInfoResponse);
+
+        // When
+        attachmentService.saveAllAttachments(bulkDataList);
+
+        // Then
+        // AttachmentRepository.saveAll 호출 검증: 첨부파일 객체 리스트가 올바르게 만들어졌는지 확인
+        ArgumentCaptor<List<Attachment>> attachmentsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(attachmentRepository, times(1)).saveAll(attachmentsCaptor.capture());
+        List<Attachment> savedAttachments = attachmentsCaptor.getValue();
+        assertEquals(1, savedAttachments.size());
+        Attachment savedAttachment = savedAttachments.get(0);
+        assertEquals("test.jpg", savedAttachment.getFileName());
+        assertEquals(fileInfoResponse.fileKey(), savedAttachment.getFileKey());
+        assertEquals(fileInfoResponse.filePath(), savedAttachment.getFilePath());
+        assertEquals(mockFile.getSize(), savedAttachment.getFileSize());
+        assertEquals(mockFile.getContentType(), savedAttachment.getFileType());
+        assertEquals("CARD", savedAttachment.getFileTarget());
+
+        // AttachmentCardTargetRepository.saveAll 호출 검증: 각 Attachment와 Card 객체가 연결되어 저장되는지 확인
+        ArgumentCaptor<List<AttachmentCardTarget>> targetCaptor = ArgumentCaptor.forClass(List.class);
+        verify(attachmentCardTargetRepository, times(1)).saveAll(targetCaptor.capture());
+        List<AttachmentCardTarget> savedTargets = targetCaptor.getValue();
+        assertEquals(1, savedTargets.size());
+        AttachmentCardTarget target = savedTargets.get(0);
+        assertEquals(dummyCard, target.getCard());
+        assertEquals(savedAttachment, target.getAttachment());
+    }
+
+
+    @Test
     void testSaveAttachment() {
         // Given
         MockMultipartFile mockFile = new MockMultipartFile(
@@ -125,22 +181,6 @@ public class AttachmentServiceTests {
         verify(attachmentDeckTargetRepository, times(1)).save(captor.capture());
         assertEquals(mockAttachment, captor.getValue().getAttachment());
         assertEquals(mockDeck, captor.getValue().getDeck());
-    }
-
-    @Test
-    void testSaveAttachmentCardTarget() {
-        // Given
-        Attachment mockAttachment = mock(Attachment.class);
-        Card mockCard = mock(Card.class);
-
-        // When
-        attachmentService.saveAttachmentCardTarget(mockAttachment, mockCard);
-
-        // Then
-        ArgumentCaptor<AttachmentCardTarget> captor = ArgumentCaptor.forClass(AttachmentCardTarget.class);
-        verify(attachmentCardTargetRepository, times(1)).save(captor.capture());
-        assertEquals(mockAttachment, captor.getValue().getAttachment());
-        assertEquals(mockCard, captor.getValue().getCard());
     }
 
     @Test

--- a/src/test/java/com/edio/service/CardServiceTests.java
+++ b/src/test/java/com/edio/service/CardServiceTests.java
@@ -185,6 +185,7 @@ public class CardServiceTests {
         ArgumentCaptor<List<String>> deleteCaptor = ArgumentCaptor.forClass(List.class);
         verify(attachmentService, times(1)).deleteAllAttachments(deleteCaptor.capture());
         List<String> deletedKeys = deleteCaptor.getValue();
+
         assertEquals(2, deletedKeys.size());
         assertTrue(deletedKeys.contains("oldImageKey"), "Old image key should be deleted");
         assertTrue(deletedKeys.contains("oldAudioKey"), "Old audio key should be deleted");
@@ -196,6 +197,7 @@ public class CardServiceTests {
         // 오직 새 이미지 파일에 대한 항목만 존재해야 함
         assertEquals(1, savedAttachments.size(), "Only one attachment (image) should be uploaded");
         AttachmentBulkData imageBulkData = savedAttachments.get(0);
+
         assertEquals(newImageFile, imageBulkData.getFile());
         assertEquals(AttachmentFolder.IMAGE.name(), imageBulkData.getFolder());
         assertEquals(FileTarget.CARD.name(), imageBulkData.getTarget());

--- a/src/test/java/com/edio/service/CardServiceTests.java
+++ b/src/test/java/com/edio/service/CardServiceTests.java
@@ -13,15 +13,12 @@ import com.edio.studywithcard.card.repository.CardRepository;
 import com.edio.studywithcard.card.service.CardServiceImpl;
 import com.edio.studywithcard.deck.domain.Deck;
 import com.edio.studywithcard.deck.repository.DeckRepository;
-import com.edio.studywithcard.folder.domain.Folder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -84,7 +81,8 @@ public class CardServiceTests {
     }
 
     private CardBulkRequestWrapper createWrapper(CardBulkRequest request) {
-        CardBulkRequestWrapper wrapper = new CardBulkRequestWrapper() {};
+        CardBulkRequestWrapper wrapper = new CardBulkRequestWrapper() {
+        };
         wrapper.setRequests(Collections.singletonList(request));
         return wrapper;
     }
@@ -103,11 +101,10 @@ public class CardServiceTests {
 
         when(deckRepository.findById(deckId)).thenReturn(Optional.of(dummyDeck));
 
-
-        // [when] 신규 카드 생성 실행
+        // When: 신규 카드 생성 실행
         cardService.upsert(accountId, wrapper);
 
-        // [then] 카드 저장 및 첨부파일 처리 검증
+        // When: 카드 저장 및 첨부파일 처리 검증
         ArgumentCaptor<List<Card>> captor = ArgumentCaptor.forClass(List.class);
         verify(cardRepository, times(1)).saveAll(captor.capture());
         List<Card> savedCards = captor.getValue();
@@ -117,7 +114,7 @@ public class CardServiceTests {
         assertEquals("Description with attachments", savedCard.getDescription());
         assertEquals(dummyDeck, savedCard.getDeck());
 
-        // [then] 첨부파일 벌크 처리 검증
+        // Then: 첨부파일 벌크 처리 검증
         ArgumentCaptor<List<AttachmentBulkData>> attachmentCaptor = ArgumentCaptor.forClass(List.class);
         verify(attachmentService, times(1)).saveAllAttachments(attachmentCaptor.capture());
         List<AttachmentBulkData> capturedAttachments = attachmentCaptor.getValue();
@@ -144,7 +141,7 @@ public class CardServiceTests {
     void 기존_카드_수정_첨부파일_업데이트_테스트() throws Exception {
         // Given: 기존 카드 수정 요청
         Long cardId = 1L;
-        CardBulkRequest request = createCardRequest(cardId,  "Updated Name", "Updated Description");
+        CardBulkRequest request = createCardRequest(cardId, "Updated Name", "Updated Description");
 
         // 새로운 파일
         MultipartFile newImageFile = mockMultipartFile(false, IMAGE_MIME_JPEG);
@@ -163,9 +160,11 @@ public class CardServiceTests {
         Attachment oldAudioAttachment = Attachment.builder().fileKey("oldAudioKey").fileType(AUDIO_MIME_MPEG).build();
 
         // Entity에서는 Setter를 제공하지 않기 때문에 ReflectionTestUtils로 값 지정
-        AttachmentCardTarget imageTarget = new AttachmentCardTarget() {};
+        AttachmentCardTarget imageTarget = new AttachmentCardTarget() {
+        };
         ReflectionTestUtils.setField(imageTarget, "attachment", oldImageAttachment);
-        AttachmentCardTarget audioTarget = new AttachmentCardTarget() {};
+        AttachmentCardTarget audioTarget = new AttachmentCardTarget() {
+        };
         ReflectionTestUtils.setField(audioTarget, "attachment", oldAudioAttachment);
         ReflectionTestUtils.setField(existingCard, "attachmentCardTargets", List.of(imageTarget, audioTarget));
 

--- a/src/test/java/com/edio/service/CardServiceTests.java
+++ b/src/test/java/com/edio/service/CardServiceTests.java
@@ -1,0 +1,196 @@
+package com.edio.service;
+
+import com.edio.studywithcard.attachment.domain.Attachment;
+import com.edio.studywithcard.attachment.domain.AttachmentCardTarget;
+import com.edio.studywithcard.attachment.domain.enums.AttachmentFolder;
+import com.edio.studywithcard.attachment.domain.enums.FileTarget;
+import com.edio.studywithcard.attachment.service.AttachmentService;
+import com.edio.studywithcard.card.domain.Card;
+import com.edio.studywithcard.card.model.request.CardBulkRequest;
+import com.edio.studywithcard.card.model.request.CardBulkRequestWrapper;
+import com.edio.studywithcard.card.repository.CardRepository;
+import com.edio.studywithcard.card.service.CardServiceImpl;
+import com.edio.studywithcard.deck.domain.Deck;
+import com.edio.studywithcard.deck.repository.DeckRepository;
+import com.edio.studywithcard.folder.domain.Folder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CardServiceTests {
+
+    private static final String IMAGE_MIME_JPEG = "image/jpeg";
+    private static final String AUDIO_MIME_MPEG = "audio/mpeg";
+    private static final Long accountId = 1L;
+    private static final Long deckId = 1L;
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private DeckRepository deckRepository;
+
+    @Mock
+    private AttachmentService attachmentService;
+
+    @InjectMocks
+    private CardServiceImpl cardService;
+
+    private Deck dummyDeck;
+    private Folder dummyFolder;
+
+    @BeforeEach
+    void setUp() {
+        dummyDeck = mock(Deck.class);
+        dummyFolder = mock(Folder.class);
+
+        when(dummyFolder.getAccountId()).thenReturn(accountId);
+        when(dummyDeck.getFolder()).thenReturn(dummyFolder);
+    }
+
+    // ==================== 헬퍼 메서드 ====================
+
+    private CardBulkRequest createCardRequest(Long cardId, String name, String description) {
+        CardBulkRequest request = new CardBulkRequest();
+        request.setCardId(cardId);
+        request.setDeckId(deckId);
+        request.setName(name);
+        request.setDescription(description);
+        return request;
+    }
+
+    private MultipartFile mockMultipartFile(boolean isEmpty, String contentType) {
+        MultipartFile file = mock(MultipartFile.class);
+        lenient().when(file.isEmpty()).thenReturn(isEmpty);
+        lenient().when(file.getContentType()).thenReturn(contentType);
+        return file;
+    }
+
+    private CardBulkRequestWrapper createWrapper(CardBulkRequest request) {
+        CardBulkRequestWrapper wrapper = new CardBulkRequestWrapper() {};
+        wrapper.setRequests(Collections.singletonList(request));
+        return wrapper;
+    }
+
+    // ==================== 테스트 ====================
+
+    @Test
+    void 신규_카드_생성_첨부파일_포함_테스트() throws Exception {
+        // Given: 신규 카드 생성 요청 및 첨부파일 모킹
+        CardBulkRequest request = createCardRequest(null, "Card with attachments", "Description with attachments");
+        MultipartFile imageFile = mockMultipartFile(false, IMAGE_MIME_JPEG);
+        MultipartFile audioFile = mockMultipartFile(false, AUDIO_MIME_MPEG);
+        request.setImage(imageFile);
+        request.setAudio(audioFile);
+        CardBulkRequestWrapper wrapper = createWrapper(request);
+
+        // 덱 조회 스텁 (요청에 사용된 deckId에 대해 dummyDeck 반환)
+        when(deckRepository.findById(eq(request.getDeckId()))).thenReturn(Optional.of(dummyDeck));
+
+        // 첨부파일 저장 시 더미 Attachment 반환 설정
+        // 이미지 저장 -> imageAttachment("imageKey")가 반환
+        // 오디오 저장 -> audioAttachment("audioKey")가 반환
+        Attachment imageAttachment = Attachment.builder().fileKey("imageKey").build();
+        Attachment audioAttachment = Attachment.builder().fileKey("audioKey").build();
+        when(attachmentService.saveAttachment(eq(imageFile), eq(AttachmentFolder.IMAGE.name()), eq(FileTarget.CARD.name())))
+                .thenReturn(imageAttachment);
+        when(attachmentService.saveAttachment(eq(audioFile), eq(AttachmentFolder.AUDIO.name()), eq(FileTarget.CARD.name())))
+                .thenReturn(audioAttachment);
+
+        // When: 카드 생성 실행
+        cardService.upsert(accountId, wrapper);
+
+        // Then: 카드 저장 및 첨부파일 처리 검증
+
+        // cardRepository.saveAll()이 한 번 호출되었는지 검증
+        ArgumentCaptor<List<Card>> cardCaptor = ArgumentCaptor.forClass(List.class);
+        verify(cardRepository, times(1)).saveAll(cardCaptor.capture());
+
+        // 저장된 카드가 1개인지 검증
+        // 카드 정보가 올바르게 저장되었는지 확인
+        List<Card> savedCards = cardCaptor.getValue();
+        assertEquals(1, savedCards.size());
+        Card savedCard = savedCards.get(0);
+        assertEquals("Card with attachments", savedCard.getName());
+        assertEquals("Description with attachments", savedCard.getDescription());
+        assertEquals(dummyDeck, savedCard.getDeck());
+
+        // 첨부 파일이 올바르게 저장되었는지 검증
+        verify(attachmentService, times(1)).saveAttachment(eq(imageFile), eq(AttachmentFolder.IMAGE.name()), eq(FileTarget.CARD.name()));
+        verify(attachmentService, times(1)).saveAttachment(eq(audioFile), eq(AttachmentFolder.AUDIO.name()), eq(FileTarget.CARD.name()));
+        verify(attachmentService, times(1)).saveAttachmentCardTarget(imageAttachment, savedCard);
+        verify(attachmentService, times(1)).saveAttachmentCardTarget(audioAttachment, savedCard);
+    }
+
+    @Test
+    void 기존_카드_수정_첨부파일_업데이트_테스트() throws Exception {
+        // Given: 기존 카드 수정 요청
+        Long cardId = 1L;
+        CardBulkRequest request = createCardRequest(cardId,  "Updated Name", "Updated Description");
+
+        // 새로운 파일
+        MultipartFile newImageFile = mockMultipartFile(false, IMAGE_MIME_JPEG);
+        MultipartFile emptyAudioFile = mockMultipartFile(true, AUDIO_MIME_MPEG);
+        request.setImage(newImageFile);
+        request.setAudio(emptyAudioFile);
+        CardBulkRequestWrapper wrapper = createWrapper(request);
+
+        // 기존 카드 및 첨부파일 설정
+        Card existingCard = Card.builder()
+                .name("Old Name")
+                .description("Old Description")
+                .build();
+        // 기존에 저장된 이미지, 오디오 첨부파일 설정
+        Attachment oldImageAttachment = Attachment.builder().fileKey("oldImageKey").fileType(IMAGE_MIME_JPEG).build();
+        Attachment oldAudioAttachment = Attachment.builder().fileKey("oldAudioKey").fileType(AUDIO_MIME_MPEG).build();
+
+        // Entity에서는 Setter를 제공하지 않기 때문에 ReflectionTestUtils로 값 지정
+        AttachmentCardTarget imageTarget = new AttachmentCardTarget() {};
+        ReflectionTestUtils.setField(imageTarget, "attachment", oldImageAttachment);
+        AttachmentCardTarget audioTarget = new AttachmentCardTarget() {};
+        ReflectionTestUtils.setField(audioTarget, "attachment", oldAudioAttachment);
+        ReflectionTestUtils.setField(existingCard, "attachmentCardTargets", List.of(imageTarget, audioTarget));
+
+        // repository 스텁 설정: cardId에 대해 기존 카드 반환
+        when(cardRepository.findByIdAndIsDeletedFalse(cardId)).thenReturn(Optional.of(existingCard));
+        when(deckRepository.findById(eq(request.getDeckId()))).thenReturn(Optional.of(dummyDeck));
+
+        // 새 이미지 저장 시 더미 Attachment 반환 설정
+        Attachment newImageAttachment = Attachment.builder().fileKey("newImageKey").build();
+        when(attachmentService.saveAttachment(eq(newImageFile), eq(AttachmentFolder.IMAGE.name()), eq(FileTarget.CARD.name())))
+                .thenReturn(newImageAttachment);
+
+        // When: 기존 카드 업데이트 실행
+        cardService.upsert(accountId, wrapper);
+
+        // Then: 카드 정보 업데이트 검증
+        assertEquals("Updated Name", existingCard.getName());
+        assertEquals("Updated Description", existingCard.getDescription());
+
+        // 이미지: 기존 이미지 삭제 후 새 이미지 저장 및 연결 검증
+        verify(attachmentService, times(1)).deleteAttachment("oldImageKey");
+        verify(attachmentService, times(1)).saveAttachment(eq(newImageFile), eq(AttachmentFolder.IMAGE.name()), eq(FileTarget.CARD.name()));
+        verify(attachmentService, times(1)).saveAttachmentCardTarget(newImageAttachment, existingCard);
+
+        // 오디오: 빈 파일이면 기존 오디오 삭제만 검증
+        verify(attachmentService, times(1)).deleteAttachment("oldAudioKey");
+        verify(attachmentService, never()).saveAttachment(eq(emptyAudioFile), eq(AttachmentFolder.AUDIO.name()), eq(FileTarget.CARD.name()));
+    }
+}


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

- 새로운 카드 등록, 기존 카드 수정 메서드 분리
- 이미지, 오디오 각 1개씩이기 때문에 Multipart 배열 처리 제거 후, files를 image와 audio로 분리
- update는 필드가 없을 경우 무시, 빈 파일일 경우 기존 파일 삭제, 새로운 파일은 기존 파일 삭제 후 업데이트
- 기존 attachment Bulk 처리 메서드는 유지하고 단일 처리 메서드 추가
- 카드 Service 로직 메서드 분리
- accounId로 권한 있는지 확인하는 로직 추가

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
