### PR TITLE
Feat/ #110 Foler 조회 N+1 문제 최적화 진행(LAZY 방식에 BatchSize 지정)

### DIFF
--- a/src/main/java/com/edio/studywithcard/folder/domain/Folder.java
+++ b/src/main/java/com/edio/studywithcard/folder/domain/Folder.java
@@ -4,6 +4,7 @@ import com.edio.common.domain.BaseEntity;
 import com.edio.studywithcard.deck.domain.Deck;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
@@ -28,10 +29,12 @@ public class Folder extends BaseEntity {
 
     @OneToMany(mappedBy = "parentFolder", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @BatchSize(size = 10)
     private List<Folder> childrenFolders = new ArrayList<>();
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    @BatchSize(size = 10)
     private List<Deck> decks = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/edio/studywithcard/folder/repository/FolderRepository.java
+++ b/src/main/java/com/edio/studywithcard/folder/repository/FolderRepository.java
@@ -23,7 +23,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
      * @param folderId
      * @return
      */
-    @EntityGraph(attributePaths = {"childrenFolders", "decks"})
     Optional<Folder> findById(Long folderId);
 
     /**


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- 기존 EntityGraph 적용 제거 및 BatchSize 지정
- EntityGraph는 1:N 관계에서 fetch join이 아닌 join만 실행(BatchSize를 지정하지 않으려면, JPQL로 fetch join 필요)
<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [x] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
![스크린샷 2025-03-11 152626](https://github.com/user-attachments/assets/2dcf3264-e62c-40e3-a3a4-3aec42af937d)

